### PR TITLE
Feature/unified file types

### DIFF
--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -58,11 +58,17 @@ impl OsmFormat {
     /// Return if the `OsmFormat` can be decoded by the lib.
     pub const fn can_read(&self) -> bool {
         match self {
+            #[cfg(feature = "json")]
             OsmFormat::Json => true,
-            OsmFormat::O5m => false,
-            OsmFormat::Opl => true,
+            #[cfg(feature = "json")]
             OsmFormat::Overpass => true,
+            #[cfg(feature = "o5m")]
+            OsmFormat::O5m => false,
+            #[cfg(feature = "opl")]
+            OsmFormat::Opl => true,
+            #[cfg(feature = "xml")]
             OsmFormat::Xml => true,
+            #[cfg(feature = "pbf")]
             OsmFormat::Pbf => true,
         }
     }
@@ -70,11 +76,17 @@ impl OsmFormat {
     /// Return if the `OsmFormat` can be encoded by the lib.
     pub const fn can_write(&self) -> bool {
         match self {
+            #[cfg(feature = "json")]
             OsmFormat::Json => true,
-            OsmFormat::O5m => true,
-            OsmFormat::Opl => true,
+            #[cfg(feature = "json")]
             OsmFormat::Overpass => true,
+            #[cfg(feature = "o5m")]
+            OsmFormat::O5m => true,
+            #[cfg(feature = "opl")]
+            OsmFormat::Opl => true,
+            #[cfg(feature = "xml")]
             OsmFormat::Xml => true,
+            #[cfg(feature = "pbf")]
             OsmFormat::Pbf => false,
         }
     }
@@ -84,12 +96,18 @@ impl OsmFormat {
     #[must_use]
     pub fn reading_enabled(&self) -> bool {
         match self {
-            OsmFormat::Json => cfg!(feature = "json"),
+            #[cfg(feature = "json")]
+            OsmFormat::Json => true,
+            #[cfg(feature = "json")]
+            OsmFormat::Overpass => true,
+            #[cfg(feature = "o5m")]
             OsmFormat::O5m => false,
-            OsmFormat::Opl => cfg!(feature = "opl"),
-            OsmFormat::Overpass => cfg!(feature = "json"),
-            OsmFormat::Xml => cfg!(feature = "xml"),
-            OsmFormat::Pbf => cfg!(feature = "pbf"),
+            #[cfg(feature = "opl")]
+            OsmFormat::Opl => true,
+            #[cfg(feature = "xml")]
+            OsmFormat::Xml => true,
+            #[cfg(feature = "pbf")]
+            OsmFormat::Pbf => true,
         }
     }
 
@@ -98,15 +116,20 @@ impl OsmFormat {
     #[must_use]
     pub fn writing_enabled(&self) -> bool {
         match self {
-            OsmFormat::Json => cfg!(feature = "json"),
-            OsmFormat::O5m => cfg!(feature = "o5m"),
-            OsmFormat::Opl => cfg!(feature = "opl"),
-            OsmFormat::Overpass => cfg!(feature = "json"),
-            OsmFormat::Xml => cfg!(feature = "xml"),
+            #[cfg(feature = "json")]
+            OsmFormat::Json => true,
+            #[cfg(feature = "json")]
+            OsmFormat::Overpass => true,
+            #[cfg(feature = "o5m")]
+            OsmFormat::O5m => true,
+            #[cfg(feature = "opl")]
+            OsmFormat::Opl => true,
+            #[cfg(feature = "xml")]
+            OsmFormat::Xml => true,
+            #[cfg(feature = "pbf")]
             OsmFormat::Pbf => false,
         }
     }
-
     /// Validates format capabilities (can be evaluated at compile time)
     #[inline]
     pub fn validate_capabilities(input: &OsmFormat, output: &OsmFormat) -> Result<(), SkywayError> {
@@ -163,14 +186,19 @@ impl OsmFormat {
         fn inner(ext: &OsStr) -> Option<OsmFormat> {
             let ext = ext.to_str()?.to_ascii_lowercase();
 
-            Some(match ext.as_str() {
-                "json" => OsmFormat::Json,
-                "o5m" => OsmFormat::O5m,
-                "opl" => OsmFormat::Opl,
-                "osm" | "xml" => OsmFormat::Xml,
-                "pbf" => OsmFormat::Pbf,
-                _ => return None,
-            })
+            match ext.as_str() {
+                #[cfg(feature = "json")]
+                "json" => Some(OsmFormat::Json),
+                #[cfg(feature = "o5m")]
+                "o5m" => Some(OsmFormat::O5m),
+                #[cfg(feature = "opl")]
+                "opl" => Some(OsmFormat::Opl),
+                #[cfg(feature = "xml")]
+                "osm" | "xml" => Some(OsmFormat::Xml),
+                #[cfg(feature = "pbf")]
+                "pbf" => Some(OsmFormat::Pbf),
+                _ => None,
+            }
         }
 
         inner(ext.as_ref())
@@ -178,14 +206,19 @@ impl OsmFormat {
 }
 
 impl fmt::Display for OsmFormat {
-    // This trait requires `fmt` with this exact signature.
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
+            #[cfg(feature = "json")]
             OsmFormat::Json => write!(f, "json")?,
-            OsmFormat::O5m => write!(f, "o5m")?,
-            OsmFormat::Opl => write!(f, "opl")?,
+            #[cfg(feature = "json")]
             OsmFormat::Overpass => write!(f, "overpass")?,
+            #[cfg(feature = "o5m")]
+            OsmFormat::O5m => write!(f, "o5m")?,
+            #[cfg(feature = "opl")]
+            OsmFormat::Opl => write!(f, "opl")?,
+            #[cfg(feature = "xml")]
             OsmFormat::Xml => write!(f, "xml")?,
+            #[cfg(feature = "pbf")]
             OsmFormat::Pbf => write!(f, "pbf")?,
         }
 

--- a/src/file_format.rs
+++ b/src/file_format.rs
@@ -1,0 +1,194 @@
+#[cfg(feature = "cli")]
+use clap::ValueEnum;
+use std::ffi::OsStr;
+use std::fmt;
+
+use crate::{FileFormatOptions, SkywayError};
+
+/// Enum that represents the different OSM file formats skyway supports.
+#[cfg(feature = "cli")]
+#[derive(Clone, Debug, ValueEnum)]
+#[non_exhaustive]
+pub enum OsmFormat {
+    #[cfg(feature = "json")]
+    #[value(name = "json")]
+    Json,
+    #[cfg(feature = "o5m")]
+    #[value(name = "o5m")]
+    O5m,
+    #[cfg(feature = "opl")]
+    #[value(name = "opl")]
+    Opl,
+    #[cfg(feature = "json")]
+    #[value(name = "overpass")]
+    Overpass,
+    #[cfg(feature = "xml")]
+    #[value(name = "xml", alias = "osm")]
+    Xml,
+    #[cfg(feature = "pbf")]
+    #[value(name = "pbf")]
+    Pbf,
+}
+
+#[cfg(not(feature = "cli"))]
+#[derive(Clone, Debug)]
+pub enum OsmFormat {
+    #[cfg(feature = "json")]
+    Json,
+    #[cfg(feature = "o5m")]
+    O5m,
+    #[cfg(feature = "opl")]
+    Opl,
+    #[cfg(feature = "json")]
+    Overpass,
+    #[cfg(feature = "xml")]
+    Xml,
+    #[cfg(feature = "pbf")]
+    Pbf,
+}
+
+#[cfg(feature = "cli")]
+impl FileFormatOptions for OsmFormat {
+    fn format_error(ext: &str) -> SkywayError {
+        SkywayError::UnknownFormat(ext.to_string())
+    }
+}
+
+impl OsmFormat {
+    /// Return if the `OsmFormat` can be decoded by the lib.
+    pub const fn can_read(&self) -> bool {
+        match self {
+            OsmFormat::Json => true,
+            OsmFormat::O5m => false,
+            OsmFormat::Opl => true,
+            OsmFormat::Overpass => true,
+            OsmFormat::Xml => true,
+            OsmFormat::Pbf => true,
+        }
+    }
+
+    /// Return if the `OsmFormat` can be encoded by the lib.
+    pub const fn can_write(&self) -> bool {
+        match self {
+            OsmFormat::Json => true,
+            OsmFormat::O5m => true,
+            OsmFormat::Opl => true,
+            OsmFormat::Overpass => true,
+            OsmFormat::Xml => true,
+            OsmFormat::Pbf => false,
+        }
+    }
+
+    /// Return the `OsmFormat`s which are enabled for reading.
+    #[inline]
+    #[must_use]
+    pub fn reading_enabled(&self) -> bool {
+        match self {
+            OsmFormat::Json => cfg!(feature = "json"),
+            OsmFormat::O5m => false,
+            OsmFormat::Opl => cfg!(feature = "opl"),
+            OsmFormat::Overpass => cfg!(feature = "json"),
+            OsmFormat::Xml => cfg!(feature = "xml"),
+            OsmFormat::Pbf => cfg!(feature = "pbf"),
+        }
+    }
+
+    /// Return the `OsmFormat`s which are enabled for writing.
+    #[inline]
+    #[must_use]
+    pub fn writing_enabled(&self) -> bool {
+        match self {
+            OsmFormat::Json => cfg!(feature = "json"),
+            OsmFormat::O5m => cfg!(feature = "o5m"),
+            OsmFormat::Opl => cfg!(feature = "opl"),
+            OsmFormat::Overpass => cfg!(feature = "json"),
+            OsmFormat::Xml => cfg!(feature = "xml"),
+            OsmFormat::Pbf => false,
+        }
+    }
+
+    /// Validates format capabilities (can be evaluated at compile time)
+    #[inline]
+    pub fn validate_capabilities(input: &OsmFormat, output: &OsmFormat) -> Result<(), SkywayError> {
+        if !input.can_read() {
+            return Err(SkywayError::UnsupportedRead(format!(
+                "format {:?} does not support reading",
+                input
+            )));
+        }
+
+        if !output.can_write() {
+            return Err(SkywayError::UnsupportedWrite(format!(
+                "format {:?} does not support writing",
+                output
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Validates feature flags are enabled
+    #[inline]
+    pub fn validate_enabled(input: &OsmFormat, output: &OsmFormat) -> Result<(), SkywayError> {
+        if !input.reading_enabled() {
+            return Err(SkywayError::UnsupportedRead(format!(
+                "reading support not enabled for format {:?}",
+                input
+            )));
+        }
+
+        if !output.writing_enabled() {
+            return Err(SkywayError::UnsupportedWrite(format!(
+                "writing support not enabled for format {:?}",
+                output
+            )));
+        }
+
+        Ok(())
+    }
+
+    /// Full validation of both capabilities and enabled features
+    pub fn validate_conversion(input: &OsmFormat, output: &OsmFormat) -> Result<(), SkywayError> {
+        Self::validate_capabilities(input, output)?;
+        Self::validate_enabled(input, output)?;
+        Ok(())
+    }
+
+    /// Return the format from a file extension
+    #[inline]
+    pub fn from_extension<S>(ext: S) -> Option<Self>
+    where
+        S: AsRef<OsStr>,
+    {
+        fn inner(ext: &OsStr) -> Option<OsmFormat> {
+            let ext = ext.to_str()?.to_ascii_lowercase();
+
+            Some(match ext.as_str() {
+                "json" => OsmFormat::Json,
+                "o5m" => OsmFormat::O5m,
+                "opl" => OsmFormat::Opl,
+                "osm" | "xml" => OsmFormat::Xml,
+                "pbf" => OsmFormat::Pbf,
+                _ => return None,
+            })
+        }
+
+        inner(ext.as_ref())
+    }
+}
+
+impl fmt::Display for OsmFormat {
+    // This trait requires `fmt` with this exact signature.
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            OsmFormat::Json => write!(f, "json")?,
+            OsmFormat::O5m => write!(f, "o5m")?,
+            OsmFormat::Opl => write!(f, "opl")?,
+            OsmFormat::Overpass => write!(f, "overpass")?,
+            OsmFormat::Xml => write!(f, "xml")?,
+            OsmFormat::Pbf => write!(f, "pbf")?,
+        }
+
+        Ok(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,11 +10,13 @@ use std::path::PathBuf;
 
 pub mod chunks;
 pub mod elements;
+mod file_format;
 pub mod readers;
 pub mod writers;
 
+pub use file_format::OsmFormat;
+
 use readers::*;
-use writers::OutputFileFormat;
 
 // selective imports that deal with filters
 #[cfg(feature = "filter")]
@@ -26,10 +28,12 @@ use filter::ElementFilter;
 // this is a work in progress
 #[derive(Error, Debug)]
 pub enum SkywayError {
-    #[error("Cannot determine input file format: {0}")]
-    UnknownInputFormat(String),
-    #[error("Cannot determine output file format: {0}")]
-    UnknownOutputFormat(String),
+    #[error("Cannot determine file format: {0}")]
+    UnknownFormat(String),
+    #[error("Cannot perform read operation: {0}")]
+    UnsupportedRead(String),
+    #[error("Cannot perform write operation: {0}")]
+    UnsupportedWrite(String),
     #[error("I/O error: {0}")]
     IoError(#[from] std::io::Error),
     #[error("File already exits")]
@@ -81,7 +85,7 @@ pub trait FileFormatOptions: ValueEnum {
 // build a file conversion
 // this is the main API for skyway
 pub struct ConversionBuilder {
-    input_format: InputFileFormat,
+    input_format: OsmFormat,
     source: Option<PathBuf>,
     #[cfg(feature = "filter")]
     filters: Vec<Box<dyn ElementFilter>>,
@@ -89,7 +93,7 @@ pub struct ConversionBuilder {
 }
 
 impl ConversionBuilder {
-    pub fn new(input_format: InputFileFormat) -> Self {
+    pub fn new(input_format: OsmFormat) -> Self {
         ConversionBuilder {
             input_format,
             source: None,
@@ -117,15 +121,18 @@ impl ConversionBuilder {
 
     pub fn run_conversion(
         self,
-        output_format: OutputFileFormat,
+        output_format: OsmFormat,
         dest: Option<PathBuf>,
         preserve_generator: bool,
     ) -> Result<(), SkywayError> {
+        // validate conversion
+        OsmFormat::validate_conversion(&self.input_format, &output_format)?;
+
         // set chunk_size, defaulting to 8000,
         // warning if user used custom value with PBF reader
         let chunk_size = if let Some(cs) = self.chunk_size {
             #[cfg(feature = "pbf")]
-            if matches!(self.input_format, InputFileFormat::Pbf) {
+            if matches!(self.input_format, OsmFormat::Pbf) {
                 warn!("Custom chunk size set, but the PBF does not support custom chunk sizes.");
             }
             cs
@@ -135,7 +142,7 @@ impl ConversionBuilder {
 
         match self.input_format {
             #[cfg(feature = "json")]
-            InputFileFormat::Json => JsonReader {}.run_conversion(
+            OsmFormat::Json => JsonReader {}.run_conversion(
                 self.source,
                 chunk_size,
                 #[cfg(feature = "filter")]
@@ -145,7 +152,7 @@ impl ConversionBuilder {
                 preserve_generator,
             ),
             #[cfg(feature = "opl")]
-            InputFileFormat::Opl => OplReader {}.run_conversion(
+            OsmFormat::Opl => OplReader {}.run_conversion(
                 self.source,
                 chunk_size,
                 #[cfg(feature = "filter")]
@@ -155,7 +162,7 @@ impl ConversionBuilder {
                 preserve_generator,
             ),
             #[cfg(feature = "pbf")]
-            InputFileFormat::Pbf => PbfReader {}.run_conversion(
+            OsmFormat::Pbf => PbfReader {}.run_conversion(
                 self.source,
                 chunk_size,
                 #[cfg(feature = "filter")]
@@ -165,7 +172,7 @@ impl ConversionBuilder {
                 preserve_generator,
             ),
             #[cfg(feature = "xml")]
-            InputFileFormat::Xml => XmlReader {}.run_conversion(
+            OsmFormat::Xml => XmlReader {}.run_conversion(
                 self.source,
                 chunk_size,
                 #[cfg(feature = "filter")]
@@ -174,6 +181,7 @@ impl ConversionBuilder {
                 dest,
                 preserve_generator,
             ),
+            _ => unreachable!(), // have already checked the validity of input and output
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,10 +4,7 @@ use log::info;
 
 use std::{path::PathBuf, process};
 
-use skyway::{
-    readers::InputFileFormat, writers::OutputFileFormat, ConversionBuilder, FileFormatOptions,
-    SkywayError,
-};
+use skyway::{ConversionBuilder, FileFormatOptions, OsmFormat, SkywayError};
 
 #[cfg(feature = "filter")]
 use skyway::filter::filter_from_path;
@@ -42,11 +39,11 @@ fn start_progress(message: &str) -> ProgressBar {
 struct Cli {
     /// Source file format
     #[arg(long)]
-    from: Option<InputFileFormat>,
+    from: Option<OsmFormat>,
 
     /// Destination file format
     #[arg(long)]
-    to: Option<OutputFileFormat>,
+    to: Option<OsmFormat>,
 
     /// Path to input file (if not given, reads from stdin)
     #[arg(long)]
@@ -83,10 +80,10 @@ fn run() -> Result<(), SkywayError> {
 
     let cli = Cli::parse();
 
-    let from = InputFileFormat::parse(cli.from, &cli.input)?;
+    let from = OsmFormat::parse(cli.from, &cli.input)?;
     info!("Input format determined: {:?}", from);
 
-    let to = OutputFileFormat::parse(cli.to, &cli.output)?;
+    let to = OsmFormat::parse(cli.to, &cli.output)?;
     info!("Output format determined: {:?}", to);
 
     let src = match cli.input {

--- a/src/readers/mod.rs
+++ b/src/readers/mod.rs
@@ -2,9 +2,6 @@
 
 use rayon::prelude::*;
 
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
-
 use std::{
     fs,
     io::{stdin, BufRead, BufReader, Read},
@@ -17,7 +14,7 @@ use crate::{
     chunks::{ChunkBuilder, ElementChunk},
     elements::Metadata,
     writers::*,
-    SkywayError,
+    OsmFormat, SkywayError,
 };
 
 #[cfg(feature = "filter")]
@@ -25,9 +22,6 @@ use crate::filter::{build_filter, ElementFilter};
 
 #[cfg(not(feature = "filter"))]
 use std::convert::identity;
-
-#[cfg(feature = "cli")]
-use crate::FileFormatOptions;
 
 #[cfg(feature = "json")]
 mod json;
@@ -51,45 +45,6 @@ pub use pbf::PbfReader;
 mod xml;
 #[cfg(feature = "xml")]
 pub use xml::XmlReader;
-
-/// Enum that represents the different input file formats skyway supports.
-#[cfg(feature = "cli")]
-#[derive(Clone, Debug, PartialEq, ValueEnum)]
-pub enum InputFileFormat {
-    #[cfg(feature = "json")]
-    #[value(name = "json")]
-    Json,
-    #[cfg(feature = "opl")]
-    #[value(name = "opl")]
-    Opl,
-    #[cfg(feature = "pbf")]
-    #[value(name = "pbf")]
-    Pbf,
-    #[cfg(feature = "xml")]
-    #[value(name = "xml", alias = "osm")]
-    Xml,
-}
-
-#[cfg(feature = "cli")]
-impl FileFormatOptions for InputFileFormat {
-    fn format_error(ext: &str) -> SkywayError {
-        SkywayError::UnknownInputFormat(ext.to_string())
-    }
-}
-
-/// Enum that represents the different input file formats skyway supports.
-#[cfg(not(feature = "cli"))]
-#[derive(Clone, Debug, PartialEq)]
-pub enum InputFileFormat {
-    #[cfg(feature = "json")]
-    Json,
-    #[cfg(feature = "opl")]
-    Opl,
-    #[cfg(feature = "pbf")]
-    Pbf,
-    #[cfg(feature = "xml")]
-    Xml,
-}
 
 pub fn open(path: PathBuf) -> Box<dyn Read + Send> {
     match fs::File::open(path) {
@@ -136,7 +91,7 @@ pub trait Reader: Sized {
         source: Option<PathBuf>,
         chunk_size: usize,
         #[cfg(feature = "filter")] filters: Vec<Box<dyn ElementFilter>>,
-        output_format: OutputFileFormat,
+        output_format: OsmFormat,
         dest: Option<PathBuf>,
         preserve_generator: bool,
     ) -> Result<(), SkywayError> {
@@ -162,25 +117,19 @@ pub trait Reader: Sized {
         #[allow(unreachable_patterns)]
         match output_format {
             #[cfg(feature = "json")]
-            OutputFileFormat::Json => {
+            OsmFormat::Json => {
                 JsonWriter { overpass: false }.write(chunk_iterator, trans_metadata_receiver, dest)
             }
             #[cfg(feature = "o5m")]
-            OutputFileFormat::O5m => {
-                O5mWriter {}.write(chunk_iterator, trans_metadata_receiver, dest)
-            }
+            OsmFormat::O5m => O5mWriter {}.write(chunk_iterator, trans_metadata_receiver, dest),
             #[cfg(feature = "opl")]
-            OutputFileFormat::Opl => {
-                OplWriter {}.write(chunk_iterator, trans_metadata_receiver, dest)
-            }
+            OsmFormat::Opl => OplWriter {}.write(chunk_iterator, trans_metadata_receiver, dest),
             #[cfg(feature = "json")]
-            OutputFileFormat::Overpass => {
+            OsmFormat::Overpass => {
                 JsonWriter { overpass: true }.write(chunk_iterator, trans_metadata_receiver, dest)
             }
             #[cfg(feature = "xml")]
-            OutputFileFormat::Xml => {
-                XmlWriter {}.write(chunk_iterator, trans_metadata_receiver, dest)
-            }
+            OsmFormat::Xml => XmlWriter {}.write(chunk_iterator, trans_metadata_receiver, dest),
             _ => Err(SkywayError::UnexpectedError(
                 "A file conversion was attempted with an unknown output format.".to_owned(),
             )),

--- a/src/writers/mod.rs
+++ b/src/writers/mod.rs
@@ -2,15 +2,9 @@
 
 use rayon::prelude::*;
 
-#[cfg(feature = "cli")]
-use clap::ValueEnum;
-
 use std::{path::PathBuf, sync::mpsc::Receiver};
 
 use crate::{chunks::ElementChunk, elements::Metadata, SkywayError};
-
-#[cfg(feature = "cli")]
-use crate::FileFormatOptions;
 
 #[cfg(feature = "json")]
 mod json;
@@ -31,50 +25,6 @@ pub use opl::OplWriter;
 mod xml;
 #[cfg(feature = "xml")]
 pub use xml::XmlWriter;
-
-/// Enum that represents the different output file formats skyway supports.
-#[cfg(feature = "cli")]
-#[derive(Clone, Debug, ValueEnum)]
-pub enum OutputFileFormat {
-    #[cfg(feature = "json")]
-    #[value(name = "json")]
-    Json,
-    #[cfg(feature = "o5m")]
-    #[value(name = "o5m")]
-    O5m,
-    #[cfg(feature = "opl")]
-    #[value(name = "opl")]
-    Opl,
-    #[cfg(feature = "json")]
-    #[value(name = "overpass")]
-    Overpass,
-    #[cfg(feature = "xml")]
-    #[value(name = "xml", alias = "osm")]
-    Xml,
-}
-
-#[cfg(feature = "cli")]
-impl FileFormatOptions for OutputFileFormat {
-    fn format_error(ext: &str) -> SkywayError {
-        SkywayError::UnknownOutputFormat(ext.to_string())
-    }
-}
-
-/// Enum that represents the different output file formats skyway supports.
-#[cfg(not(feature = "cli"))]
-#[derive(Clone, Debug)]
-pub enum OutputFileFormat {
-    #[cfg(feature = "json")]
-    Json,
-    #[cfg(feature = "o5m")]
-    O5m,
-    #[cfg(feature = "opl")]
-    Opl,
-    #[cfg(feature = "json")]
-    Overpass,
-    #[cfg(feature = "xml")]
-    Xml,
-}
 
 /// `Writer` implements the output of OpenStreetMap data in a specific format.
 pub trait Writer {


### PR DESCRIPTION
# API change: Unified FileFormat enum

Currently, the API uses separate enums for InputFileFormat and OutputFileFormat,  I feel like it might be cleaner to use a singular enum OsmFormat which methods for checking if they are compatible to read and write. I feel this makes it more user friendly particularly when using as a library.

## Changes
- Combined InputFileFormat and OutputFileFormat into OsmFormat
- Added methods to validate that that the read or write is correct (respecting feature flags)
- Added UnknownFormat, UnsupportedRead, UnsupportedWrite error types

## Benefits
- Simpler API surface
- More intuitive to use as a library
- Eliminates redundancy in format definitions
- Makes it easier to add new formats in the future and update capabilities 

Please let me know what you think, love the project!

###  Test 

Just to show the output when a unsupported format is used

cargo run -- --from o5m --to opl --input ./src/examples/example.json
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/skyway --from o5m --to opl --input ./src/examples/example.json`
     
 ⠋ Running conversion...                                                                                                                                                                          Error: Cannot perform read operation: format O5m does not support reading

 cargo run -- --from json --to pbf --input ./src/examples/example.json
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.08s
     Running `target/debug/skyway --from json --to pbf --input ./src/examples/example.json`
 ⠋ Running conversion...                                                                                                                                                                          Error: Cannot perform write operation: format Pbf does not support writing
 
